### PR TITLE
fix(docs): fix typo in api/ API docs

### DIFF
--- a/openprescribing/templates/api.html
+++ b/openprescribing/templates/api.html
@@ -62,7 +62,7 @@
 
 <p>
   You can use the above queries with all the other organisation types supported
-  by OpenPrescribing by changine the <code>org_type</code> parameter:
+  by OpenPrescribing by changing the <code>org_type</code> parameter:
 </p>
 <ul>
   <li><code>?org_type=pcn</code> for PCNs</li>


### PR DESCRIPTION
Hello folks,
I noticed what looks like a typo in the API docs at https://openprescribing.net/api/.

I think that a PR like this is the best way to fix it. 
Please let me know if there is a better way.

Thanks for the docs in general: they really helped me get my head around the API.